### PR TITLE
Replace async-trait with native async and generics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,9 @@
 
 The `Storage` trait (`crates/pokeplanner-storage/src/traits.rs`) provides:
 - `save_job`, `get_job`, `list_jobs`, `update_job`
+- Uses native async via `impl Future` return types (no `async-trait` dependency)
 - Currently implemented by `JsonFileStorage` (JSON files in `data/jobs/`)
+- `PokePlannerService<S: Storage>` is generic over the storage implementation — concrete type resolved at each binary's `main()`
 - Designed for future swap to SQL or NoSQL — only implement the trait
 
 ## Job Lifecycle

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -833,7 +833,6 @@ dependencies = [
 name = "pokeplanner-service"
 version = "0.1.0"
 dependencies = [
- "async-trait",
  "chrono",
  "pokeplanner-core",
  "pokeplanner-storage",
@@ -847,7 +846,6 @@ dependencies = [
 name = "pokeplanner-storage"
 version = "0.1.0"
 dependencies = [
- "async-trait",
  "pokeplanner-core",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,3 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 # HTTP middleware
 tower = "0.5"
-
-# Async trait
-async-trait = "0.1"

--- a/crates/pokeplanner-api-grpc/src/main.rs
+++ b/crates/pokeplanner-api-grpc/src/main.rs
@@ -14,7 +14,7 @@ use proto::poke_planner_service_server::{PokePlannerServiceServer, PokePlannerSe
 use proto::*;
 
 pub struct GrpcHandler {
-    service: Arc<PokePlannerService>,
+    service: Arc<PokePlannerService<JsonFileStorage>>,
 }
 
 #[tonic::async_trait]

--- a/crates/pokeplanner-api-rest/src/main.rs
+++ b/crates/pokeplanner-api-rest/src/main.rs
@@ -14,7 +14,7 @@ use serde_json::json;
 use tracing_subscriber::EnvFilter;
 use uuid::Uuid;
 
-type AppState = Arc<PokePlannerService>;
+type AppState = Arc<PokePlannerService<JsonFileStorage>>;
 
 #[tokio::main]
 async fn main() {

--- a/crates/pokeplanner-service/Cargo.toml
+++ b/crates/pokeplanner-service/Cargo.toml
@@ -6,7 +6,6 @@ edition.workspace = true
 [dependencies]
 pokeplanner-core = { workspace = true }
 pokeplanner-storage = { workspace = true }
-async-trait = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }

--- a/crates/pokeplanner-service/src/lib.rs
+++ b/crates/pokeplanner-service/src/lib.rs
@@ -5,12 +5,12 @@ use pokeplanner_core::{AppError, HealthResponse, Job, JobId, JobResult, JobStatu
 use pokeplanner_storage::Storage;
 use tracing::info;
 
-pub struct PokePlannerService {
-    storage: Arc<dyn Storage>,
+pub struct PokePlannerService<S: Storage> {
+    storage: Arc<S>,
 }
 
-impl PokePlannerService {
-    pub fn new(storage: Arc<dyn Storage>) -> Self {
+impl<S: Storage> PokePlannerService<S> {
+    pub fn new(storage: Arc<S>) -> Self {
         Self { storage }
     }
 
@@ -49,7 +49,7 @@ impl PokePlannerService {
         self.storage.list_jobs().await
     }
 
-    async fn run_job(storage: Arc<dyn Storage>, job_id: JobId) {
+    async fn run_job(storage: Arc<S>, job_id: JobId) {
         // Mark as running
         if let Ok(mut job) = storage.get_job(&job_id).await {
             job.status = JobStatus::Running;
@@ -79,7 +79,7 @@ mod tests {
 
     use super::*;
 
-    async fn make_service() -> PokePlannerService {
+    async fn make_service() -> PokePlannerService<JsonFileStorage> {
         let dir = tempfile::tempdir().unwrap();
         let storage = Arc::new(JsonFileStorage::new(dir.keep()).await.unwrap());
         PokePlannerService::new(storage)

--- a/crates/pokeplanner-storage/Cargo.toml
+++ b/crates/pokeplanner-storage/Cargo.toml
@@ -7,7 +7,6 @@ edition.workspace = true
 pokeplanner-core = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-async-trait = { workspace = true }
 thiserror = { workspace = true }
 uuid = { workspace = true }
 tokio = { workspace = true, features = ["fs", "sync"] }

--- a/crates/pokeplanner-storage/src/json_store.rs
+++ b/crates/pokeplanner-storage/src/json_store.rs
@@ -1,6 +1,5 @@
 use std::path::PathBuf;
 
-use async_trait::async_trait;
 use pokeplanner_core::{AppError, Job, JobId};
 use tokio::sync::RwLock;
 
@@ -27,7 +26,6 @@ impl JsonFileStorage {
     }
 }
 
-#[async_trait]
 impl Storage for JsonFileStorage {
     async fn save_job(&self, job: &Job) -> Result<(), AppError> {
         let _guard = self.lock.write().await;

--- a/crates/pokeplanner-storage/src/traits.rs
+++ b/crates/pokeplanner-storage/src/traits.rs
@@ -1,12 +1,15 @@
-use async_trait::async_trait;
+use std::future::Future;
+
 use pokeplanner_core::{AppError, Job, JobId};
 
 /// Storage trait providing a flexible interface for persistence.
 /// Currently backed by JSON files, but designed for future SQL/NoSQL integration.
-#[async_trait]
-pub trait Storage: Send + Sync {
-    async fn save_job(&self, job: &Job) -> Result<(), AppError>;
-    async fn get_job(&self, id: &JobId) -> Result<Job, AppError>;
-    async fn list_jobs(&self) -> Result<Vec<Job>, AppError>;
-    async fn update_job(&self, job: &Job) -> Result<(), AppError>;
+///
+/// Uses native async via `impl Future` (no `async-trait` dependency). The `+ Send`
+/// bound on returned futures ensures compatibility with multithreaded runtimes like tokio.
+pub trait Storage: Send + Sync + 'static {
+    fn save_job(&self, job: &Job) -> impl Future<Output = Result<(), AppError>> + Send;
+    fn get_job(&self, id: &JobId) -> impl Future<Output = Result<Job, AppError>> + Send;
+    fn list_jobs(&self) -> impl Future<Output = Result<Vec<Job>, AppError>> + Send;
+    fn update_job(&self, job: &Job) -> impl Future<Output = Result<(), AppError>> + Send;
 }

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -17,8 +17,6 @@
 | **chrono** | 0.4 | Date/time handling | Full-featured datetime library with serde and timezone support |
 | **tracing** | 0.1 | Structured logging | Async-aware, structured, composable instrumentation |
 | **tracing-subscriber** | 0.3 | Log output | Configurable subscribers with env-filter for log levels |
-| **async-trait** | 0.1 | Async trait support | Enables async methods in traits (used for Storage trait) |
-
 ## Build Dependencies
 
 | Dependency | Version | Purpose |
@@ -31,3 +29,4 @@
 - **Tonic for gRPC**: Tonic is the only mature gRPC framework in Rust and integrates seamlessly with the tokio ecosystem.
 - **thiserror + anyhow**: `thiserror` for library crates (strongly typed errors), `anyhow` for the CLI binary (ergonomic error propagation).
 - **Trait-based storage**: The `Storage` trait in `pokeplanner-storage` is designed to be implementation-agnostic. JSON file storage is the current implementation, but the interface supports future migration to SQL (e.g., sqlx) or NoSQL (e.g., MongoDB) without changing the service layer.
+- **Native async traits over async-trait**: The `Storage` trait uses native `impl Future` return types (Rust 1.75+) with explicit `+ Send` bounds instead of the `async-trait` crate. Combined with generics on `PokePlannerService<S: Storage>`, this avoids heap-allocated boxed futures and eliminates the `async-trait` dependency.


### PR DESCRIPTION
## Summary
- Replace `async-trait` with native `impl Future` return types on the `Storage` trait (Rust 1.75+)
- Make `PokePlannerService<S: Storage>` generic over the storage backend instead of using `Arc<dyn Storage>`
- Remove `async-trait` dependency from `pokeplanner-storage`, `pokeplanner-service`, and the workspace root

## Test plan
- [x] All 16 existing tests pass (`cargo test`)
- [ ] Verify REST API starts and responds to `/health` endpoint
- [ ] Verify gRPC server starts and responds to health RPC
- [ ] Verify CLI commands work (`pokeplanner hello`, `pokeplanner submit-job`)

https://claude.ai/code/session_01WRx58evtCAeWZPdJFWLhfi