### PR TITLE
Add Nix flake devShell with direnv integration

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ target
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# nix-direnv
+.direnv/

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,110 @@
+# Install
+
+PokePlanner uses [Nix](https://nixos.org/) with [direnv](https://direnv.net/) to provide a reproducible development environment. Once set up, all dependencies (Rust toolchain, protobuf, buf, openssl) are managed automatically.
+
+## Prerequisites
+
+### 1. Install Nix
+
+Install Nix with flake support enabled:
+
+```bash
+curl -L https://install.determinate.systems/nix | sh -s -- install
+```
+
+This installer from [Determinate Systems](https://github.com/DeterminateSystems/nix-installer) enables flakes and the unified CLI by default.
+
+Alternatively, use the official installer and enable flakes manually:
+
+```bash
+sh <(curl -L https://nixos.org/nix/install) --daemon
+```
+
+Then add to `~/.config/nix/nix.conf`:
+
+```
+experimental-features = nix-command flakes
+```
+
+### 2. Install direnv
+
+Install direnv via your system package manager or Nix:
+
+```bash
+# Via Nix (recommended if you already have Nix)
+nix profile install nixpkgs#direnv
+
+# Or via system package manager
+# Ubuntu/Debian: sudo apt install direnv
+# macOS:         brew install direnv
+```
+
+### 3. Hook direnv into your shell
+
+Add the appropriate line to your shell config:
+
+```bash
+# zsh (~/.zshrc)
+eval "$(direnv hook zsh)"
+
+# bash (~/.bashrc)
+eval "$(direnv hook bash)"
+
+# fish (~/.config/fish/config.fish)
+direnv hook fish | source
+```
+
+Restart your shell or source the config file after adding the hook.
+
+## Getting started
+
+1. Clone the repository and `cd` into it:
+
+   ```bash
+   git clone <repo-url> pokeplanner
+   cd pokeplanner
+   ```
+
+2. Allow direnv to load the environment:
+
+   ```bash
+   direnv allow
+   ```
+
+   The first run will download and build the Nix dependencies (Rust toolchain, protobuf, buf, openssl). Subsequent loads are instant.
+
+3. Verify the setup:
+
+   ```bash
+   rustc --version
+   cargo --version
+   protoc --version
+   buf --version
+   ```
+
+4. Build and test:
+
+   ```bash
+   cargo build
+   cargo test
+   ```
+
+## Without direnv
+
+If you prefer not to use direnv, enter the dev shell manually:
+
+```bash
+nix develop
+```
+
+This drops you into a shell with all dependencies available. You need to run this each time you open a new terminal.
+
+## What the dev shell provides
+
+| Tool       | Purpose                          |
+|------------|----------------------------------|
+| Rust (stable, latest) | Compiler, cargo, rust-analyzer, rust-src |
+| protobuf   | `protoc` compiler for gRPC       |
+| buf        | Proto file management            |
+| pkg-config | Native dependency resolution     |
+| openssl    | TLS support                      |

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,82 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1773840656,
+        "narHash": "sha256-9tpvMGFteZnd3gRQZFlRCohVpqooygFuy9yjuyRL2C0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9cf7092bdd603554bd8b63c216e8943cf9b12512",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774062094,
+        "narHash": "sha256-ba3c+hS7KzEiwtZRGHagIAYdcmdY3rCSWVCyn64rx7s=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "c807e83cc2e32adc35f51138b3bdef722c0812ab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,61 @@
+{
+  description = "PokePlanner – Rust workspace with REST, gRPC, and CLI";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, rust-overlay, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        overlays = [ (import rust-overlay) ];
+        pkgs = import nixpkgs { inherit system overlays; };
+
+        rustToolchain = pkgs.rust-bin.stable.latest.default.override {
+          extensions = [ "rust-src" "rust-analyzer" ];
+        };
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          buildInputs = [
+            rustToolchain
+            pkgs.protobuf     # protoc for tonic-build
+            pkgs.buf          # buf CLI for proto management
+            pkgs.pkg-config
+            pkgs.openssl
+          ];
+
+          PROTOC = "${pkgs.protobuf}/bin/protoc";
+        };
+
+        packages.default = pkgs.rustPlatform.buildRustPackage {
+          pname = "pokeplanner";
+          version = "0.1.0";
+
+          src = ./.;
+          cargoLock.lockFile = ./Cargo.lock;
+
+          nativeBuildInputs = [
+            pkgs.protobuf
+            pkgs.pkg-config
+          ];
+
+          buildInputs = [
+            pkgs.openssl
+          ];
+
+          PROTOC = "${pkgs.protobuf}/bin/protoc";
+
+          meta = {
+            description = "PokePlanner – Pokémon team planning service";
+            license = pkgs.lib.licenses.mit;
+          };
+        };
+      }
+    );
+}


### PR DESCRIPTION
## Summary
- Add `flake.nix` with a devShell providing Rust toolchain (+ rust-analyzer), protoc, pkg-config, and openssl
- Add `.envrc` for automatic environment loading via nix-direnv
- Add `.direnv/` to `.gitignore`

## Setup
1. Install [nix-direnv](https://github.com/nix-community/nix-direnv)
2. Run `direnv allow` in the project root
3. The dev environment loads automatically on `cd`

## Test plan
- [x] `direnv allow` loads the flake devShell without errors
- [x] `cargo build` succeeds within the nix shell
- [x] `cargo test` passes
- [x] `protoc --version` is available (needed for gRPC codegen)

🤖 Generated with [Claude Code](https://claude.com/claude-code)