### PR TITLE
Add gRPC proto messages and handlers for new RPCs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,8 +114,14 @@ Jobs are submitted, assigned a UUID, and processed asynchronously via `tokio::sp
 | `Health` | Health check |
 | `Ping` | Echo ping/pong |
 | `SubmitJob` | Submit a new job |
-| `GetJob` | Get job by ID |
+| `GetJob` | Get job by ID (includes kind, progress, result data) |
 | `ListJobs` | List all jobs |
+| `GetVersionGroups` | List available games (version groups) |
+| `GetGamePokemon` | Get pokemon for a game (supports min_bst, sort, limit, variants) |
+| `GetPokedexPokemon` | Get pokemon from a pokedex |
+| `GetPokemon` | Get single pokemon details |
+| `PlanTeam` | Submit team planning job (game/pokedex/custom source, counter-team) |
+| `AnalyzeTeam` | Synchronous type coverage analysis |
 
 ### CLI
 | Command | Description |

--- a/crates/pokeplanner-api-grpc/src/main.rs
+++ b/crates/pokeplanner-api-grpc/src/main.rs
@@ -1,5 +1,8 @@
 use std::sync::Arc;
 
+use pokeplanner_core::{
+    AppError, SortField, SortOrder, TeamPlanRequest, TeamSource,
+};
 use pokeplanner_pokeapi::PokeApiHttpClient;
 use pokeplanner_service::PokePlannerService;
 use pokeplanner_storage::JsonFileStorage;
@@ -18,6 +21,89 @@ use proto::*;
 
 pub struct GrpcHandler {
     service: Arc<PokePlannerService<JsonFileStorage, PokeApiHttpClient>>,
+}
+
+impl GrpcHandler {
+    fn pokemon_to_proto(p: &pokeplanner_core::Pokemon) -> Pokemon {
+        Pokemon {
+            species_name: p.species_name.clone(),
+            form_name: p.form_name.clone(),
+            pokedex_number: p.pokedex_number,
+            types: p.types.iter().map(|t| t.to_string()).collect(),
+            stats: Some(BaseStats {
+                hp: p.stats.hp,
+                attack: p.stats.attack,
+                defense: p.stats.defense,
+                special_attack: p.stats.special_attack,
+                special_defense: p.stats.special_defense,
+                speed: p.stats.speed,
+            }),
+            is_default_form: p.is_default_form,
+            bst: p.bst(),
+        }
+    }
+
+    fn coverage_to_proto(c: &pokeplanner_core::TypeCoverage) -> TypeCoverage {
+        TypeCoverage {
+            offensive_coverage: c.offensive_coverage.iter().map(|t| t.to_string()).collect(),
+            defensive_weaknesses: c
+                .defensive_weaknesses
+                .iter()
+                .map(|t| t.to_string())
+                .collect(),
+            uncovered_types: c.uncovered_types.iter().map(|t| t.to_string()).collect(),
+            coverage_score: c.coverage_score,
+        }
+    }
+
+    fn job_to_proto(job: &pokeplanner_core::Job) -> GetJobResponse {
+        GetJobResponse {
+            id: job.id.to_string(),
+            status: format!("{:?}", job.status),
+            kind: format!("{:?}", job.kind),
+            created_at: job.created_at.to_rfc3339(),
+            updated_at: job.updated_at.to_rfc3339(),
+            result_message: job.result.as_ref().map(|r| r.message.clone()),
+            result_data: job
+                .result
+                .as_ref()
+                .and_then(|r| r.data.as_ref().map(|d| d.to_string())),
+            progress: job.progress.as_ref().map(|p| JobProgress {
+                phase: p.phase.clone(),
+                completed_steps: p.completed_steps,
+                total_steps: p.total_steps,
+            }),
+        }
+    }
+
+    fn proto_sort_field(f: i32) -> Option<SortField> {
+        match proto::SortField::try_from(f) {
+            Ok(proto::SortField::Bst) => Some(SortField::Bst),
+            Ok(proto::SortField::Hp) => Some(SortField::Hp),
+            Ok(proto::SortField::Attack) => Some(SortField::Attack),
+            Ok(proto::SortField::Defense) => Some(SortField::Defense),
+            Ok(proto::SortField::SpecialAttack) => Some(SortField::SpecialAttack),
+            Ok(proto::SortField::SpecialDefense) => Some(SortField::SpecialDefense),
+            Ok(proto::SortField::Speed) => Some(SortField::Speed),
+            Ok(proto::SortField::Name) => Some(SortField::Name),
+            Ok(proto::SortField::PokedexNumber) => Some(SortField::PokedexNumber),
+            Err(_) => None,
+        }
+    }
+
+    fn proto_sort_order(o: i32) -> SortOrder {
+        match proto::SortOrder::try_from(o) {
+            Ok(proto::SortOrder::Desc) => SortOrder::Desc,
+            _ => SortOrder::Asc,
+        }
+    }
+
+    fn app_error_to_status(e: AppError) -> Status {
+        match &e {
+            AppError::NotFound(_) | AppError::JobNotFound(_) => Status::not_found(e.to_string()),
+            _ => Status::internal(e.to_string()),
+        }
+    }
 }
 
 #[tonic::async_trait]
@@ -48,7 +134,7 @@ impl GrpcService for GrpcHandler {
             .service
             .submit_job()
             .await
-            .map_err(|e| Status::internal(e.to_string()))?;
+            .map_err(Self::app_error_to_status)?;
         Ok(Response::new(SubmitJobResponse {
             job_id: job_id.to_string(),
         }))
@@ -64,14 +150,8 @@ impl GrpcService for GrpcHandler {
             .service
             .get_job(&job_id)
             .await
-            .map_err(|e| Status::not_found(e.to_string()))?;
-        Ok(Response::new(GetJobResponse {
-            id: job.id.to_string(),
-            status: format!("{:?}", job.status),
-            created_at: job.created_at.to_rfc3339(),
-            updated_at: job.updated_at.to_rfc3339(),
-            result_output: job.result.map(|r| r.message),
-        }))
+            .map_err(Self::app_error_to_status)?;
+        Ok(Response::new(Self::job_to_proto(&job)))
     }
 
     async fn list_jobs(
@@ -82,18 +162,153 @@ impl GrpcService for GrpcHandler {
             .service
             .list_jobs()
             .await
-            .map_err(|e| Status::internal(e.to_string()))?;
-        let jobs = jobs
+            .map_err(Self::app_error_to_status)?;
+        let jobs = jobs.iter().map(Self::job_to_proto).collect();
+        Ok(Response::new(ListJobsResponse { jobs }))
+    }
+
+    async fn get_version_groups(
+        &self,
+        req: Request<GetVersionGroupsRequest>,
+    ) -> Result<Response<GetVersionGroupsResponse>, Status> {
+        let inner = req.into_inner();
+        let groups = self
+            .service
+            .list_version_groups(inner.no_cache)
+            .await
+            .map_err(Self::app_error_to_status)?;
+        let version_groups = groups
             .into_iter()
-            .map(|job| GetJobResponse {
-                id: job.id.to_string(),
-                status: format!("{:?}", job.status),
-                created_at: job.created_at.to_rfc3339(),
-                updated_at: job.updated_at.to_rfc3339(),
-                result_output: job.result.map(|r| r.message),
+            .map(|g| VersionGroupInfo {
+                name: g.name,
+                versions: g.versions,
+                pokedexes: g.pokedexes,
             })
             .collect();
-        Ok(Response::new(ListJobsResponse { jobs }))
+        Ok(Response::new(GetVersionGroupsResponse { version_groups }))
+    }
+
+    async fn get_game_pokemon(
+        &self,
+        req: Request<GetGamePokemonRequest>,
+    ) -> Result<Response<GetGamePokemonResponse>, Status> {
+        let inner = req.into_inner();
+        let pokemon = self
+            .service
+            .get_game_pokemon(
+                &inner.version_group,
+                inner.min_bst,
+                inner.no_cache,
+                Self::proto_sort_field(inner.sort_by),
+                Self::proto_sort_order(inner.sort_order),
+                inner.include_variants,
+                inner.limit.map(|l| l as usize),
+            )
+            .await
+            .map_err(Self::app_error_to_status)?;
+        let count = pokemon.len() as u32;
+        let pokemon = pokemon.iter().map(Self::pokemon_to_proto).collect();
+        Ok(Response::new(GetGamePokemonResponse { pokemon, count }))
+    }
+
+    async fn get_pokedex_pokemon(
+        &self,
+        req: Request<GetPokedexPokemonRequest>,
+    ) -> Result<Response<GetPokedexPokemonResponse>, Status> {
+        let inner = req.into_inner();
+        let pokemon = self
+            .service
+            .get_pokedex_pokemon(
+                &inner.pokedex_name,
+                inner.min_bst,
+                inner.no_cache,
+                Self::proto_sort_field(inner.sort_by),
+                Self::proto_sort_order(inner.sort_order),
+                inner.include_variants,
+                inner.limit.map(|l| l as usize),
+            )
+            .await
+            .map_err(Self::app_error_to_status)?;
+        let count = pokemon.len() as u32;
+        let pokemon = pokemon.iter().map(Self::pokemon_to_proto).collect();
+        Ok(Response::new(GetPokedexPokemonResponse { pokemon, count }))
+    }
+
+    async fn get_pokemon(
+        &self,
+        req: Request<GetPokemonRequest>,
+    ) -> Result<Response<GetPokemonResponse>, Status> {
+        let inner = req.into_inner();
+        let pokemon = self
+            .service
+            .get_pokemon(&inner.name, inner.no_cache)
+            .await
+            .map_err(Self::app_error_to_status)?;
+        Ok(Response::new(GetPokemonResponse {
+            pokemon: Some(Self::pokemon_to_proto(&pokemon)),
+        }))
+    }
+
+    async fn plan_team(
+        &self,
+        req: Request<PlanTeamRequest>,
+    ) -> Result<Response<PlanTeamResponse>, Status> {
+        let inner = req.into_inner();
+        let source = match inner.source {
+            Some(team_source) => match team_source.source {
+                Some(team_source::Source::Game(vg)) => TeamSource::Game {
+                    version_group: vg,
+                },
+                Some(team_source::Source::Pokedex(name)) => TeamSource::Pokedex {
+                    pokedex_name: name,
+                },
+                Some(team_source::Source::Custom(list)) => TeamSource::Custom {
+                    pokemon_names: list.pokemon_names,
+                },
+                None => return Err(Status::invalid_argument("TeamSource variant is required")),
+            },
+            None => return Err(Status::invalid_argument("source is required")),
+        };
+        let request = TeamPlanRequest {
+            source,
+            min_bst: inner.min_bst,
+            no_cache: inner.no_cache,
+            top_k: inner.top_k.map(|k| k as usize),
+            include_variants: inner.include_variants,
+            counter_team: if inner.counter_team.is_empty() {
+                None
+            } else {
+                Some(inner.counter_team)
+            },
+        };
+        let job_id = self
+            .service
+            .submit_team_plan(request)
+            .await
+            .map_err(Self::app_error_to_status)?;
+        Ok(Response::new(PlanTeamResponse {
+            job_id: job_id.to_string(),
+        }))
+    }
+
+    async fn analyze_team(
+        &self,
+        req: Request<AnalyzeTeamRequest>,
+    ) -> Result<Response<AnalyzeTeamResponse>, Status> {
+        let inner = req.into_inner();
+        if inner.pokemon_names.is_empty() {
+            return Err(Status::invalid_argument(
+                "pokemon_names must not be empty",
+            ));
+        }
+        let coverage = self
+            .service
+            .analyze_team(inner.pokemon_names, inner.no_cache)
+            .await
+            .map_err(Self::app_error_to_status)?;
+        Ok(Response::new(AnalyzeTeamResponse {
+            coverage: Some(Self::coverage_to_proto(&coverage)),
+        }))
     }
 }
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -44,7 +44,7 @@ PokePlanner is a Rust workspace organized into a layered architecture with clear
 ## Job System
 
 The job system supports long-running operations:
-1. Client submits a job via `POST /jobs` (REST) or `SubmitJob` (gRPC) or CLI
+1. Client submits a job via `POST /jobs` (REST) or `SubmitJob`/`PlanTeam` (gRPC) or CLI
 2. Service creates a `Pending` job with a `JobKind` (Generic or TeamPlan), persists it, and returns the job ID immediately
 3. A background task picks up the job, transitions it through `Running` -> `Completed`/`Failed`
 4. Job `progress` field is updated during long operations (e.g., "Fetching pokemon 47/312")
@@ -52,7 +52,7 @@ The job system supports long-running operations:
 
 ## Team Planning Flow
 
-1. User selects a source: game (version-group) or custom pokemon list
+1. User selects a source: game (version-group), pokedex, or custom pokemon list
 2. Service fetches candidate pokemon via PokeAPI (cached aggressively, 1-year TTL)
 3. Optional BST filter reduces candidates
 4. **Hybrid algorithm** selects optimal teams:

--- a/docs/IMPLEMENTATION_CHECKLIST.md
+++ b/docs/IMPLEMENTATION_CHECKLIST.md
@@ -27,6 +27,6 @@
 - [x] 4.5 CLAUDE.md updated
 
 ## Future Work
-- [ ] gRPC proto messages for new RPCs (PlanTeam, GetGamePokemon, etc.)
+- [x] gRPC proto messages for new RPCs (PlanTeam, GetGamePokemon, etc.)
 - [ ] Integration tests with mocked HTTP responses
 - [ ] Stale job recovery on startup (Running → Failed for interrupted jobs)

--- a/proto/pokeplanner.proto
+++ b/proto/pokeplanner.proto
@@ -8,7 +8,15 @@ service PokePlannerService {
   rpc SubmitJob (SubmitJobRequest) returns (SubmitJobResponse);
   rpc GetJob (GetJobRequest) returns (GetJobResponse);
   rpc ListJobs (ListJobsRequest) returns (ListJobsResponse);
+  rpc GetVersionGroups (GetVersionGroupsRequest) returns (GetVersionGroupsResponse);
+  rpc GetGamePokemon (GetGamePokemonRequest) returns (GetGamePokemonResponse);
+  rpc GetPokedexPokemon (GetPokedexPokemonRequest) returns (GetPokedexPokemonResponse);
+  rpc GetPokemon (GetPokemonRequest) returns (GetPokemonResponse);
+  rpc PlanTeam (PlanTeamRequest) returns (PlanTeamResponse);
+  rpc AnalyzeTeam (AnalyzeTeamRequest) returns (AnalyzeTeamResponse);
 }
+
+// --- Common types ---
 
 message HealthRequest {}
 
@@ -25,6 +33,34 @@ message PingResponse {
   string message = 1;
 }
 
+message BaseStats {
+  uint32 hp = 1;
+  uint32 attack = 2;
+  uint32 defense = 3;
+  uint32 special_attack = 4;
+  uint32 special_defense = 5;
+  uint32 speed = 6;
+}
+
+message Pokemon {
+  string species_name = 1;
+  string form_name = 2;
+  uint32 pokedex_number = 3;
+  repeated string types = 4;
+  BaseStats stats = 5;
+  bool is_default_form = 6;
+  uint32 bst = 7;
+}
+
+message TypeCoverage {
+  repeated string offensive_coverage = 1;
+  repeated string defensive_weaknesses = 2;
+  repeated string uncovered_types = 3;
+  double coverage_score = 4;
+}
+
+// --- Job messages ---
+
 message SubmitJobRequest {}
 
 message SubmitJobResponse {
@@ -35,16 +71,141 @@ message GetJobRequest {
   string job_id = 1;
 }
 
+message JobProgress {
+  string phase = 1;
+  uint32 completed_steps = 2;
+  uint32 total_steps = 3;
+}
+
 message GetJobResponse {
   string id = 1;
   string status = 2;
-  string created_at = 3;
-  string updated_at = 4;
-  optional string result_output = 5;
+  string kind = 3;
+  string created_at = 4;
+  string updated_at = 5;
+  optional string result_message = 6;
+  optional string result_data = 7;
+  optional JobProgress progress = 8;
 }
 
 message ListJobsRequest {}
 
 message ListJobsResponse {
   repeated GetJobResponse jobs = 1;
+}
+
+// --- Version groups ---
+
+message GetVersionGroupsRequest {
+  bool no_cache = 1;
+}
+
+message VersionGroupInfo {
+  string name = 1;
+  repeated string versions = 2;
+  repeated string pokedexes = 3;
+}
+
+message GetVersionGroupsResponse {
+  repeated VersionGroupInfo version_groups = 1;
+}
+
+// --- Game pokemon ---
+
+enum SortField {
+  SORT_FIELD_BST = 0;
+  SORT_FIELD_HP = 1;
+  SORT_FIELD_ATTACK = 2;
+  SORT_FIELD_DEFENSE = 3;
+  SORT_FIELD_SPECIAL_ATTACK = 4;
+  SORT_FIELD_SPECIAL_DEFENSE = 5;
+  SORT_FIELD_SPEED = 6;
+  SORT_FIELD_NAME = 7;
+  SORT_FIELD_POKEDEX_NUMBER = 8;
+}
+
+enum SortOrder {
+  SORT_ORDER_ASC = 0;
+  SORT_ORDER_DESC = 1;
+}
+
+message GetGamePokemonRequest {
+  string version_group = 1;
+  optional uint32 min_bst = 2;
+  bool no_cache = 3;
+  SortField sort_by = 4;
+  SortOrder sort_order = 5;
+  bool include_variants = 6;
+  optional uint32 limit = 7;
+}
+
+message GetGamePokemonResponse {
+  repeated Pokemon pokemon = 1;
+  uint32 count = 2;
+}
+
+// --- Pokedex pokemon ---
+
+message GetPokedexPokemonRequest {
+  string pokedex_name = 1;
+  optional uint32 min_bst = 2;
+  bool no_cache = 3;
+  SortField sort_by = 4;
+  SortOrder sort_order = 5;
+  bool include_variants = 6;
+  optional uint32 limit = 7;
+}
+
+message GetPokedexPokemonResponse {
+  repeated Pokemon pokemon = 1;
+  uint32 count = 2;
+}
+
+// --- Single pokemon ---
+
+message GetPokemonRequest {
+  string name = 1;
+  bool no_cache = 2;
+}
+
+message GetPokemonResponse {
+  Pokemon pokemon = 1;
+}
+
+// --- Team planning ---
+
+message TeamSource {
+  oneof source {
+    string game = 1;
+    string pokedex = 2;
+    CustomPokemonList custom = 3;
+  }
+}
+
+message CustomPokemonList {
+  repeated string pokemon_names = 1;
+}
+
+message PlanTeamRequest {
+  TeamSource source = 1;
+  optional uint32 min_bst = 2;
+  bool no_cache = 3;
+  optional uint32 top_k = 4;
+  bool include_variants = 5;
+  repeated string counter_team = 6;
+}
+
+message PlanTeamResponse {
+  string job_id = 1;
+}
+
+// --- Team analysis ---
+
+message AnalyzeTeamRequest {
+  repeated string pokemon_names = 1;
+  bool no_cache = 2;
+}
+
+message AnalyzeTeamResponse {
+  TypeCoverage coverage = 1;
 }


### PR DESCRIPTION
## Summary
- Adds 6 new gRPC RPCs (`GetVersionGroups`, `GetGamePokemon`, `GetPokedexPokemon`, `GetPokemon`, `PlanTeam`, `AnalyzeTeam`) with full proto message definitions to match existing REST endpoints
- Implements gRPC handler methods with core↔proto type conversion, enum mapping, and consistent error handling
- Enhances `GetJobResponse` to include `kind`, `progress`, and `result_data` fields
- Updates CLAUDE.md, ARCHITECTURE.md, and IMPLEMENTATION_CHECKLIST.md

## Test plan
- [x] `cargo build` passes cleanly
- [x] `cargo test` — all 71 tests pass
- [ ] Manual smoke test: start gRPC server, call new RPCs via `grpcurl`

🤖 Generated with [Claude Code](https://claude.com/claude-code)