### PR TITLE
Extend PokeAPI client to capture move meta and stat_changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@
 
 - **Core types**: `crates/pokeplanner-core/` — shared models (Pokemon, Move, MoveStatChange, LearnsetEntry, DetailedLearnsetEntry, RecommendedMove, MoveRole), errors, job types, team types
 - **Storage**: `crates/pokeplanner-storage/` — `Storage` trait + `JsonFileStorage`
-- **PokeAPI Client**: `crates/pokeplanner-pokeapi/` — `PokeApiClient` trait + `PokeApiHttpClient` with disk cache and rate limiting
+- **PokeAPI Client**: `crates/pokeplanner-pokeapi/` — `PokeApiClient` trait + `PokeApiHttpClient` with disk cache and rate limiting. `MoveResponse` includes `meta` (drain, stat_chance, etc.) and `stat_changes` fields for move safety filtering
 - **Service**: `crates/pokeplanner-service/` — business logic, job orchestration, team planner, type chart
 - **REST API**: `crates/pokeplanner-api-rest/` — Axum server on port 3000
 - **gRPC API**: `crates/pokeplanner-api-grpc/` — Tonic server on port 50051

--- a/crates/pokeplanner-pokeapi/src/client.rs
+++ b/crates/pokeplanner-pokeapi/src/client.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use futures::stream::{self, StreamExt};
 use governor::{Quota, RateLimiter};
 use pokeplanner_core::{
-    AppError, BaseStats, LearnMethod, LearnsetEntry, Move, Pokemon, PokemonType,
+    AppError, BaseStats, LearnMethod, LearnsetEntry, Move, MoveStatChange, Pokemon, PokemonType,
 };
 use tracing::{debug, warn};
 
@@ -572,6 +572,26 @@ impl PokeApiClient for PokeApiHttpClient {
             })
             .map(|e| e.short_effect.clone());
 
+        let drain = resp.meta.as_ref().map(|m| m.drain).unwrap_or(0);
+        let stat_chance = resp.meta.as_ref().map(|m| m.stat_chance).unwrap_or(0);
+
+        // stat_chance == 0 means "always applies" in PokeAPI convention.
+        // stat_chance >= 100 also means guaranteed.
+        let guaranteed = stat_chance == 0 || stat_chance >= 100;
+
+        let self_stat_changes = if guaranteed {
+            resp.stat_changes
+                .iter()
+                .filter(|sc| sc.change < 0)
+                .map(|sc| MoveStatChange {
+                    stat: sc.stat.name.clone(),
+                    change: sc.change,
+                })
+                .collect()
+        } else {
+            Vec::new()
+        };
+
         Ok(Move {
             name: resp.name,
             move_type,
@@ -581,8 +601,157 @@ impl PokeApiClient for PokeApiHttpClient {
             damage_class: resp.damage_class.name,
             priority: resp.priority,
             effect,
-            drain: 0,
-            self_stat_changes: Vec::new(),
+            drain,
+            self_stat_changes,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{MoveMeta, MoveStatChangeResponse, NamedApiResource};
+
+    /// Helper to build a MoveResponse with the given meta and stat_changes.
+    fn make_move_response(
+        meta: Option<MoveMeta>,
+        stat_changes: Vec<MoveStatChangeResponse>,
+    ) -> MoveResponse {
+        MoveResponse {
+            id: 1,
+            name: "test-move".to_string(),
+            type_info: NamedApiResource {
+                name: "fire".to_string(),
+                url: String::new(),
+            },
+            power: Some(100),
+            accuracy: Some(100),
+            pp: Some(10),
+            damage_class: NamedApiResource {
+                name: "special".to_string(),
+                url: String::new(),
+            },
+            priority: 0,
+            effect_entries: Vec::new(),
+            meta,
+            stat_changes,
+        }
+    }
+
+    fn make_meta(drain: i32, stat_chance: i32) -> MoveMeta {
+        MoveMeta {
+            drain,
+            healing: 0,
+            crit_rate: 0,
+            ailment_chance: 0,
+            flinch_chance: 0,
+            stat_chance,
+        }
+    }
+
+    fn make_stat_change(stat: &str, change: i32) -> MoveStatChangeResponse {
+        MoveStatChangeResponse {
+            change,
+            stat: NamedApiResource {
+                name: stat.to_string(),
+                url: String::new(),
+            },
+        }
+    }
+
+    #[test]
+    fn test_mapping_drain_from_meta() {
+        let resp = make_move_response(Some(make_meta(-25, 0)), Vec::new());
+        let drain = resp.meta.as_ref().map(|m| m.drain).unwrap_or(0);
+        assert_eq!(drain, -25);
+    }
+
+    #[test]
+    fn test_mapping_drain_defaults_without_meta() {
+        let resp = make_move_response(None, Vec::new());
+        let drain = resp.meta.as_ref().map(|m| m.drain).unwrap_or(0);
+        assert_eq!(drain, 0);
+    }
+
+    #[test]
+    fn test_mapping_guaranteed_self_debuff_stat_chance_zero() {
+        // stat_chance == 0 means guaranteed in PokeAPI
+        let resp = make_move_response(
+            Some(make_meta(0, 0)),
+            vec![make_stat_change("special-attack", -2)],
+        );
+        let stat_chance = resp.meta.as_ref().map(|m| m.stat_chance).unwrap_or(0);
+        let guaranteed = stat_chance == 0 || stat_chance >= 100;
+        assert!(guaranteed);
+
+        let self_stat_changes: Vec<MoveStatChange> = resp
+            .stat_changes
+            .iter()
+            .filter(|sc| sc.change < 0)
+            .map(|sc| MoveStatChange {
+                stat: sc.stat.name.clone(),
+                change: sc.change,
+            })
+            .collect();
+        assert_eq!(self_stat_changes.len(), 1);
+        assert_eq!(self_stat_changes[0].stat, "special-attack");
+        assert_eq!(self_stat_changes[0].change, -2);
+    }
+
+    #[test]
+    fn test_mapping_non_guaranteed_debuff_excluded() {
+        // stat_chance == 30 means 30% probability — not guaranteed, so excluded
+        let resp = make_move_response(
+            Some(make_meta(0, 30)),
+            vec![make_stat_change("defense", -1)],
+        );
+        let stat_chance = resp.meta.as_ref().map(|m| m.stat_chance).unwrap_or(0);
+        let guaranteed = stat_chance == 0 || stat_chance >= 100;
+        assert!(!guaranteed);
+
+        let self_stat_changes: Vec<MoveStatChange> = if guaranteed {
+            resp.stat_changes
+                .iter()
+                .filter(|sc| sc.change < 0)
+                .map(|sc| MoveStatChange {
+                    stat: sc.stat.name.clone(),
+                    change: sc.change,
+                })
+                .collect()
+        } else {
+            Vec::new()
+        };
+        assert!(self_stat_changes.is_empty());
+    }
+
+    #[test]
+    fn test_mapping_positive_stat_changes_excluded() {
+        // Positive changes (boosts) should not appear in self_stat_changes
+        let resp = make_move_response(
+            Some(make_meta(0, 0)),
+            vec![
+                make_stat_change("attack", 2),
+                make_stat_change("defense", -1),
+            ],
+        );
+        let self_stat_changes: Vec<MoveStatChange> = resp
+            .stat_changes
+            .iter()
+            .filter(|sc| sc.change < 0)
+            .map(|sc| MoveStatChange {
+                stat: sc.stat.name.clone(),
+                change: sc.change,
+            })
+            .collect();
+        assert_eq!(self_stat_changes.len(), 1);
+        assert_eq!(self_stat_changes[0].stat, "defense");
+    }
+
+    #[test]
+    fn test_mapping_stat_chance_100_is_guaranteed() {
+        let resp = make_move_response(Some(make_meta(0, 100)), vec![make_stat_change("speed", -1)]);
+        let stat_chance = resp.meta.as_ref().map(|m| m.stat_chance).unwrap_or(0);
+        let guaranteed = stat_chance == 0 || stat_chance >= 100;
+        assert!(guaranteed);
     }
 }

--- a/crates/pokeplanner-pokeapi/src/types.rs
+++ b/crates/pokeplanner-pokeapi/src/types.rs
@@ -111,6 +111,29 @@ pub struct MoveEffectEntry {
     pub language: NamedApiResource,
 }
 
+/// Metadata from the PokeAPI `meta` object on a move response.
+///
+/// - `drain`: percentage of damage drained as HP. Negative = recoil (user loses HP),
+///   positive = HP drain (user recovers HP), 0 = neither.
+/// - `stat_chance`: probability that the move's `stat_changes` apply. **0 means guaranteed**
+///   (not "never") — this is PokeAPI's convention. Values 1–99 are probabilities; ≥100 is guaranteed.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MoveMeta {
+    pub drain: i32,
+    pub healing: i32,
+    pub crit_rate: i32,
+    pub ailment_chance: i32,
+    pub flinch_chance: i32,
+    pub stat_chance: i32,
+}
+
+/// A stat change entry from the top-level `stat_changes` array on a move response.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MoveStatChangeResponse {
+    pub change: i32,
+    pub stat: NamedApiResource,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MoveResponse {
     pub id: u32,
@@ -124,6 +147,10 @@ pub struct MoveResponse {
     pub priority: i32,
     #[serde(default)]
     pub effect_entries: Vec<MoveEffectEntry>,
+    #[serde(default)]
+    pub meta: Option<MoveMeta>,
+    #[serde(default)]
+    pub stat_changes: Vec<MoveStatChangeResponse>,
 }
 
 // --- Type ---
@@ -199,5 +226,82 @@ mod tests {
         assert_eq!(vg.name, "red-blue");
         assert_eq!(vg.pokedexes.len(), 1);
         assert_eq!(vg.versions.len(), 2);
+    }
+
+    #[test]
+    fn test_move_meta_deser() {
+        let json = r#"{
+            "drain": -25,
+            "healing": 0,
+            "crit_rate": 0,
+            "ailment_chance": 0,
+            "flinch_chance": 0,
+            "stat_chance": 0
+        }"#;
+        let meta: MoveMeta = serde_json::from_str(json).unwrap();
+        assert_eq!(meta.drain, -25);
+        assert_eq!(meta.stat_chance, 0);
+    }
+
+    #[test]
+    fn test_move_stat_change_response_deser() {
+        let json = r#"{
+            "change": -2,
+            "stat": {"name": "special-attack", "url": ""}
+        }"#;
+        let sc: MoveStatChangeResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(sc.change, -2);
+        assert_eq!(sc.stat.name, "special-attack");
+    }
+
+    #[test]
+    fn test_move_response_with_meta_and_stat_changes() {
+        let json = r#"{
+            "id": 315, "name": "overheat",
+            "type": {"name": "fire", "url": ""},
+            "power": 130, "accuracy": 90, "pp": 5,
+            "damage_class": {"name": "special", "url": ""},
+            "priority": 0, "effect_entries": [],
+            "meta": {"drain": 0, "healing": 0, "crit_rate": 0, "ailment_chance": 0, "flinch_chance": 0, "stat_chance": 0},
+            "stat_changes": [{"change": -2, "stat": {"name": "special-attack", "url": ""}}]
+        }"#;
+        let resp: MoveResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.name, "overheat");
+        let meta = resp.meta.unwrap();
+        assert_eq!(meta.stat_chance, 0);
+        assert_eq!(meta.drain, 0);
+        assert_eq!(resp.stat_changes.len(), 1);
+        assert_eq!(resp.stat_changes[0].change, -2);
+        assert_eq!(resp.stat_changes[0].stat.name, "special-attack");
+    }
+
+    #[test]
+    fn test_move_response_without_meta_backward_compat() {
+        let json = r#"{
+            "id": 85, "name": "thunderbolt",
+            "type": {"name": "electric", "url": ""},
+            "power": 90, "accuracy": 100, "pp": 15,
+            "damage_class": {"name": "special", "url": ""},
+            "priority": 0, "effect_entries": []
+        }"#;
+        let resp: MoveResponse = serde_json::from_str(json).unwrap();
+        assert!(resp.meta.is_none());
+        assert!(resp.stat_changes.is_empty());
+    }
+
+    #[test]
+    fn test_move_response_with_recoil() {
+        let json = r#"{
+            "id": 394, "name": "flare-blitz",
+            "type": {"name": "fire", "url": ""},
+            "power": 120, "accuracy": 100, "pp": 15,
+            "damage_class": {"name": "physical", "url": ""},
+            "priority": 0, "effect_entries": [],
+            "meta": {"drain": -33, "healing": 0, "crit_rate": 0, "ailment_chance": 10, "flinch_chance": 0, "stat_chance": 0},
+            "stat_changes": []
+        }"#;
+        let resp: MoveResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.meta.unwrap().drain, -33);
+        assert!(resp.stat_changes.is_empty());
     }
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -68,7 +68,16 @@ version-group/{name} → pokedexes[]
 pokedex/{name} → pokemon_entries[] (species names)
 pokemon-species/{name} → varieties[] (forms: base, mega, regional)
 pokemon/{form_name} → stats[], types[]
+move/{name} → type, power, accuracy, pp, damage_class, meta, stat_changes
 ```
+
+### Move metadata semantics
+
+The `/move/{name}` endpoint returns two fields used for move safety filtering:
+
+- **`meta.drain`** (i32): percentage of damage drained as HP. Negative = recoil (user loses HP, e.g. Flare Blitz: -33), positive = HP drain (e.g. Giga Drain: 50), 0 = neither.
+- **`meta.stat_chance`** (i32): probability that `stat_changes` apply. **0 means guaranteed** (not "never") — this is PokeAPI's convention. Values 1–99 are probabilities; ≥100 is also guaranteed. For example, Overheat has `stat_chance: 0` with `stat_changes: [{change: -2, stat: "special-attack"}]`, meaning the SpAtk drop always occurs.
+- **`stat_changes`** (array): top-level array of `{change: i32, stat: NamedApiResource}`. Only negative entries (debuffs) with guaranteed application are captured in the core `Move.self_stat_changes` field.
 
 ## Caching Strategy
 


### PR DESCRIPTION
## Summary

Closes #30 (sub-issue of #28)

- Add `MoveMeta` and `MoveStatChangeResponse` deserialization types to `pokeplanner-pokeapi` for the PokeAPI move endpoint's `meta` and `stat_changes` fields
- Update `get_move()` mapping to populate `Move.drain` and `Move.self_stat_changes` from the API response, filtering to only guaranteed self-debuffs (`stat_chance == 0` or `>= 100`, `change < 0`)
- Add deserialization tests for the new types, backward-compat tests for cached JSON without the new fields, and mapping-logic unit tests covering guaranteed vs probabilistic debuffs
- Document `stat_chance` semantics (0 = guaranteed, not "never") in `docs/ARCHITECTURE.md`

## Test plan

- [x] `MoveMeta` deserializes from representative JSON
- [x] `MoveStatChangeResponse` deserializes correctly
- [x] `MoveResponse` with full `meta` and `stat_changes` deserializes
- [x] `MoveResponse` without `meta` deserializes with `None` (backward compat)
- [x] `MoveResponse` without `stat_changes` deserializes with empty vec
- [x] Mapping: `drain: -25` maps correctly
- [x] Mapping: guaranteed debuff (`stat_chance: 0`) produces `self_stat_changes` entry
- [x] Mapping: non-guaranteed debuff (`stat_chance: 30`) produces empty `self_stat_changes`
- [x] Mapping: positive stat changes (boosts) are excluded
- [x] Mapping: `stat_chance: 100` is treated as guaranteed
- [x] `just ci` passes (format, lint, check, test, build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)