### PR TITLE
Improve Docker setup: action versions, publish triggers, runtime volumes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,32 @@
+# Version-control metadata
+.git
+
+# Rust build artefacts – rebuilt inside Docker
+target
+
+# Nix / direnv development environment
+.direnv
+flake.nix
+flake.lock
+.envrc
+
+# Frontend assets (not used by the API services)
+frontend
+
+# Dashboards and operations runbooks
+dashboards
+ops
+
+# Development tooling and documentation
+tools
+docs
+
+# Markdown documentation files
+AGENTS.md
+CLAUDE.md
+CONTRIBUTING.md
+INSTALL.md
+README.md
+
+# GitHub Actions configuration
+.github

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,14 +158,14 @@ jobs:
       matrix:
         service: [rest, grpc]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-qemu-action@v4
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
       - name: Build ${{ matrix.service }} image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           target: ${{ matrix.service }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,3 +147,29 @@ jobs:
 
       - name: just build
         run: nix develop --command just build
+
+  docker:
+    name: Docker Build
+    runs-on: ubuntu-latest
+    needs: [check]
+    permissions:
+      contents: read
+    strategy:
+      matrix:
+        service: [rest, grpc]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-qemu-action@v3
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Build ${{ matrix.service }} image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: ${{ matrix.service }}
+          platforms: linux/amd64,linux/arm64
+          push: false
+          cache-from: type=gha,scope=docker-${{ matrix.service }}
+          cache-to: type=gha,mode=max,scope=docker-${{ matrix.service }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,65 @@
+name: Publish
+
+on:
+  push:
+    tags: ["v*.*.*"]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish (e.g. 1.2.3, without 'v' prefix)"
+        required: true
+        type: string
+
+env:
+  REGISTRY: ghcr.io
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  publish:
+    name: Publish ${{ matrix.service }} API
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        service: [rest, grpc]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-qemu-action@v3
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository }}/${{ matrix.service }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=${{ inputs.version }},enable=${{ github.event_name == 'workflow_dispatch' }}
+
+      - name: Build and push ${{ matrix.service }} image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: ${{ matrix.service }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=publish-docker-${{ matrix.service }}
+          cache-to: type=gha,mode=max,scope=publish-docker-${{ matrix.service }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,14 +28,14 @@ jobs:
       matrix:
         service: [rest, grpc]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-qemu-action@v4
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -43,7 +43,7 @@ jobs:
 
       - name: Generate image metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository }}/${{ matrix.service }}
           tags: |
@@ -53,7 +53,7 @@ jobs:
             type=raw,value=${{ inputs.version }},enable=${{ github.event_name == 'workflow_dispatch' }}
 
       - name: Build and push ${{ matrix.service }} image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           target: ${{ matrix.service }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,9 @@ FROM gcr.io/distroless/cc-debian12 AS rest
 COPY --from=builder /app/target/release/pokeplanner-rest /pokeplanner-rest
 
 EXPOSE 3000
-ENTRYPOINT ["/pokeplanner-rest"]
+VOLUME ["/data"]
+ENV POKEPLANNER_DATA_DIR=/data
+ENTRYPOINT ["/pokeplanner-rest", "--cache-dir", "/data/cache", "--data-dir", "/data/jobs"]
 
 # ─── Stage 5: gRPC API production image ───────────────────────────────────────
 FROM gcr.io/distroless/cc-debian12 AS grpc
@@ -45,4 +47,6 @@ FROM gcr.io/distroless/cc-debian12 AS grpc
 COPY --from=builder /app/target/release/pokeplanner-grpc /pokeplanner-grpc
 
 EXPOSE 50051
-ENTRYPOINT ["/pokeplanner-grpc"]
+VOLUME ["/data"]
+ENV POKEPLANNER_DATA_DIR=/data
+ENTRYPOINT ["/pokeplanner-grpc", "--cache-dir", "/data/cache", "--data-dir", "/data/jobs"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,48 @@
+# ─── Stage 1: Rust + cargo-chef + system build dependencies ──────────────────
+FROM lukemathwalker/cargo-chef:latest-rust-slim AS chef
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+       protobuf-compiler \
+       pkg-config \
+       libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# ─── Stage 2: Compute the dependency recipe ───────────────────────────────────
+FROM chef AS planner
+
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+# ─── Stage 3: Build & cache all dependencies, then build the binaries ─────────
+FROM chef AS builder
+
+ENV PROTOC=/usr/bin/protoc
+
+# Restore dependency artifacts (re-run only when Cargo.toml / Cargo.lock change)
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json
+
+# Copy the full workspace source and proto definitions
+COPY . .
+
+# Build both API binaries in one pass (shares the already-compiled dependency layer)
+RUN cargo build --release --bin pokeplanner-rest --bin pokeplanner-grpc
+
+# ─── Stage 4: REST API production image ───────────────────────────────────────
+FROM gcr.io/distroless/cc-debian12 AS rest
+
+COPY --from=builder /app/target/release/pokeplanner-rest /pokeplanner-rest
+
+EXPOSE 3000
+ENTRYPOINT ["/pokeplanner-rest"]
+
+# ─── Stage 5: gRPC API production image ───────────────────────────────────────
+FROM gcr.io/distroless/cc-debian12 AS grpc
+
+COPY --from=builder /app/target/release/pokeplanner-grpc /pokeplanner-grpc
+
+EXPOSE 50051
+ENTRYPOINT ["/pokeplanner-grpc"]

--- a/justfile
+++ b/justfile
@@ -46,3 +46,14 @@ install-hooks:
 uninstall-hooks:
     @rm -f .git/hooks/pre-commit
     @echo "Pre-commit hook removed"
+
+# Build a Docker image for a service (rest or grpc), or both if omitted
+docker service="all":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ "{{ service }}" = "all" ]; then
+        just docker rest
+        just docker grpc
+    else
+        docker build --target "{{ service }}" -t "pokeplanner-{{ service }}" .
+    fi


### PR DESCRIPTION
## Summary

Improvements to the Docker support from #49, intended to be merged into that PR branch.

- **Bump all GHA actions to latest majors**: checkout@v6, setup-qemu@v4, setup-buildx@v4, build-push@v7, login@v4, metadata@v6
- **Publish triggers**: remove push-to-main (was publishing on every merge); now only fires on semver tags (`v*.*.*`) and `workflow_dispatch` with a required `version` input
- **Dockerfile runtime fix**: add `/data` volume and explicit `--cache-dir`/`--data-dir` entrypoint flags — distroless containers have no home directory, so the default `~/.pokeplanner` path would fail at runtime
- **Justfile simplification**: collapse `docker-rest`, `docker-grpc`, `docker-build` into a single parameterized `docker` recipe (`just docker rest`, `just docker grpc`, or `just docker` for both)

Also opened #50 to track adding binary GitHub Releases with `cargo-binstall` support.

## Test plan

- [ ] CI docker build job passes for both rest/grpc matrix entries
- [ ] `just docker rest` and `just docker grpc` build successfully locally
- [ ] `docker run pokeplanner-rest` starts and writes cache/jobs to `/data/`
- [ ] Publish workflow only triggers on tag push or manual dispatch with version

https://claude.ai/code/session_01UbARFtP2Z8wwp4K2mxMJVT
